### PR TITLE
fix #11628 for postgresql

### DIFF
--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -39,7 +39,7 @@ class JFormFieldMenuParent extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT(a.id) AS value, a.title AS text, a.level')
+			->select('DISTINCT(a.id) AS value, a.title AS text, a.level, a.lft')
 			->from('#__menu AS a');
 
 		// Filter by menu type.


### PR DESCRIPTION
fix for #11628
in postgresql don't work as it is now , it give an **SQL ERROR**
 for the `ORDER BY` clause field used `a.lft` must be in the select list of fields when the `SELECT` use `DISTINCT()`
